### PR TITLE
Add closed and chaged events

### DIFF
--- a/lib/ImgScreen.vue
+++ b/lib/ImgScreen.vue
@@ -72,6 +72,7 @@ export default {
       currentImageIndex: 0,
       closed: true,
       uiTimeout: null,
+      handlers: {}
     }
   },
   methods: {
@@ -80,6 +81,15 @@ export default {
       this.images = [];
       this.currentImageIndex = 0;
       this.closed = true;
+      // fire closed event
+      if (this.handlers.closed) {
+        this.handlers.closed();
+      }
+    },
+    fireChangeEvent() {
+      if (this.handlers.changed) {
+        this.handlers.changed(this.currentImageIndex);
+      }
     },
     next() {
       // if next index not exists in array of images, set index to first element
@@ -88,6 +98,7 @@ export default {
       } else {
         this.currentImageIndex = 0;
       };
+      this.fireChangeEvent();
     },
     prev() {
       // if prev index not exists in array of images, set index to last element
@@ -96,6 +107,7 @@ export default {
       } else {
         this.currentImageIndex = this.images.length - 1;
       };
+      this.fireChangeEvent();
     },
     showUI() {
       // UI's hidden, we reveal it for some time only on mouse move and

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const install = (Vue, options) => {
   const Screen = Vue.extend(ImgScreen);
 
   const defaultOptions = {
-    altAsTitle: false,
+	  altAsTitle: false,
   };
 
   // eslint-disable-next-line no-param-reassign
@@ -20,6 +20,8 @@ const install = (Vue, options) => {
       let src = el.src; // eslint-disable-line prefer-destructuring
       let group = binding.arg || null;
       let title;
+      let closed = null;
+      let changed = null;
 
       if (options.altAsTitle) title = el.alt;
 
@@ -29,6 +31,8 @@ const install = (Vue, options) => {
         src = binding.value.src || src;
         group = binding.value.group || group;
         title = binding.value.title || title;
+        closed = binding.value.closed;
+        changed = binding.value.changed;
       }
 
       // Setting up data attributes for groups of images
@@ -65,6 +69,12 @@ const install = (Vue, options) => {
           Vue.set(vm, 'titles', images.map(e => e.dataset.vueImgTitle));
           Vue.set(vm, 'currentImageIndex', images.indexOf(el));
         }
+        if (closed || changed) {
+          Vue.set(vm, 'handlers', {
+            closed: closed,
+            changed: changed
+          });
+        };
         Vue.set(vm, 'closed', false);
       });
     },


### PR DESCRIPTION
I added two events, 'closed' and 'changed',to your component. They are configured through the options. The event 'closed' is fired by gallery closing. The event 'changed' fired when there is a change of image from the group. I implemented for myself but I hope this implementation will be interesting to you.

example
```
<template>
   <img v-img="{closed: closed, changed: changed}">
</template>
<script>
export default {
  methods: {
    closed() {
      // run some code when gallery close
    },
    changed(index) {
      // some code when image changes (changed index passed as argument)
    }
  }
}
```
